### PR TITLE
Allow manually running the workflow on a single branch

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,17 @@
+name: Update Container Image (Nightly Matrix)
+on:
+  schedule:
+  - cron: '0 3 * * *'
+jobs:
+  update-container-image-linux-rbe:
+    uses: ./.github/workflows/rbe_configs_gen.yaml
+    with:
+      branch: linux-rbe
+  update-container-image-linux-rbe-experimental:
+    uses: ./.github/workflows/rbe_configs_gen.yaml
+    with:
+      branch: linux-rbe-experimental
+  update-container-image-buildfarm-shard-worker-rabbitmq-server-buildenv:
+    uses: ./.github/workflows/rbe_configs_gen.yaml
+    with:
+      branch: buildfarm-shard-worker-rabbitmq-server-buildenv

--- a/.github/workflows/rbe_configs_gen.yaml
+++ b/.github/workflows/rbe_configs_gen.yaml
@@ -37,15 +37,7 @@ jobs:
           linux-rbe-experimental )
             IMAGE=pivotalrabbitmq/rabbitmq-server-buildenv:linux-rbe-experimental ;;
           buildfarm-shard-worker-rabbitmq-server-buildenv )
-            # The buildfarm-shard-worker base image sets an entrypoint that breaks
-            # rbe_configs_gen
-            # Therefore, we create a local image that drops the entrypoint and use
-            # it, knowing that we drop the image from the exec_properties of the
-            # final config anyway
-            CHILD_IMAGE="buildfarm-shard-worker-rabbitmq-server-buildenv:2.8.0"
-            docker build . \
-              -t "$CHILD_IMAGE"
-            IMAGE="$CHILD_IMAGE" ;;
+            IMAGE=pivotalrabbitmq/buildfarm-shard-worker-rabbitmq-server-buildenv-noentry:2.8.0 ;;
         esac
         echo "IMAGE=$IMAGE" | tee -a $GITHUB_OUTPUT
     - name: CHECKOUT bazel-toolchains

--- a/.github/workflows/rbe_configs_gen.yaml
+++ b/.github/workflows/rbe_configs_gen.yaml
@@ -27,13 +27,25 @@ jobs:
     - name: SELECT IMAGE
       id: select-image
       run: |
+        cat << EOF > Dockerfile
+          FROM pivotalrabbitmq/buildfarm-shard-worker-rabbitmq-server-buildenv:2.8.0
+          ENTRYPOINT []
+        EOF
         case ${{ env.BRANCH }} in
           linux-rbe )
             IMAGE=pivotalrabbitmq/rabbitmq-server-buildenv:linux-rbe ;;
           linux-rbe-experimental )
             IMAGE=pivotalrabbitmq/rabbitmq-server-buildenv:linux-rbe-experimental ;;
           buildfarm-shard-worker-rabbitmq-server-buildenv )
-            IMAGE=pivotalrabbitmq/buildfarm-shard-worker-rabbitmq-server-buildenv:2.8.0 ;;
+            # The buildfarm-shard-worker base image sets an entrypoint that breaks
+            # rbe_configs_gen
+            # Therefore, we create a local image that drops the entrypoint and use
+            # it, knowing that we drop the image from the exec_properties of the
+            # final config anyway
+            CHILD_IMAGE="buildfarm-shard-worker-rabbitmq-server-buildenv:2.8.0"
+            docker build . \
+              -t "$CHILD_IMAGE"
+            IMAGE="$CHILD_IMAGE" ;;
         esac
         echo "IMAGE=$IMAGE" | tee -a $GITHUB_OUTPUT
     - name: CHECKOUT bazel-toolchains
@@ -55,9 +67,9 @@ jobs:
           --exec_os=linux \
           --target_os=linux \
           --cleanup=false
-    - name: Setup tmate session
-      if: always()
-      uses: mxschmitt/action-tmate@v3
+    # - name: Setup tmate session
+    #   if: always()
+    #   uses: mxschmitt/action-tmate@v3
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.4.0
       with:
@@ -66,7 +78,11 @@ jobs:
     - name: EXTRACT ARCHIVE
       working-directory: rbe-erlang-platform
       run: |
-        tar -xvf ../rbe_default.tar 
+        tar -xvf ../rbe_default.tar
+    - name: MAYBE PATCH
+      if: ${{ env.BRANCH }} == "buildfarm-shard-worker-rabbitmq-server-buildenv"
+      run: |
+        echo TODO
     - name: CREATE PULL REQUEST
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/rbe_configs_gen.yaml
+++ b/.github/workflows/rbe_configs_gen.yaml
@@ -1,28 +1,41 @@
 name: Update Container Image
 on:
-  schedule:
-  - cron: '0 3 * * *'
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch on this repo to checkout
+        required: true
+        default: linux-rbe
+        type: choice
+        options:
+          - linux-rbe
+          - linux-rbe-experimental
+          - buildfarm-shard-worker-rabbitmq-server-buildenv
 jobs:
   update-container-image:
     name: Update Container Image
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        branch:
-        - linux-rbe
-        - linux-rbe-experimental
-        - buildfarm-shard-worker-rabbitmq-server-buildenv
-        include:
-        - branch: linux-rbe
-          image: pivotalrabbitmq/rabbitmq-server-buildenv:linux-rbe
-        - branch: linux-rbe-experimental
-          image: pivotalrabbitmq/rabbitmq-server-buildenv:linux-rbe-experimental
-        - branch: buildfarm-shard-worker-rabbitmq-server-buildenv
-          image: pivotalrabbitmq/buildfarm-shard-worker-rabbitmq-server-buildenv:2.8.0
     timeout-minutes: 15
+    env:
+      BRANCH: ${{ inputs.branch || github.event.inputs.branch }}
     steps:
+    - name: SELECT IMAGE
+      id: select-image
+      run: |
+        case ${{ env.BRANCH }} in
+          linux-rbe )
+            IMAGE=pivotalrabbitmq/rabbitmq-server-buildenv:linux-rbe ;;
+          linux-rbe-experimental )
+            IMAGE=pivotalrabbitmq/rabbitmq-server-buildenv:linux-rbe-experimental ;;
+          buildfarm-shard-worker-rabbitmq-server-buildenv )
+            IMAGE=pivotalrabbitmq/buildfarm-shard-worker-rabbitmq-server-buildenv:2.8.0 ;;
+        esac
+        echo "IMAGE=$IMAGE" | tee -a $GITHUB_OUTPUT
     - name: CHECKOUT bazel-toolchains
       uses: actions/checkout@v2.4.0
       with:
@@ -37,7 +50,7 @@ jobs:
     - name: RUN rbe_configs_gen
       run: |
         ./rbe_configs_gen \
-          --toolchain_container=${{ matrix.image }} \
+          --toolchain_container=${{ steps.select-image.outputs.IMAGE }} \
           --output_tarball=rbe_default.tar \
           --exec_os=linux \
           --target_os=linux
@@ -45,7 +58,7 @@ jobs:
       uses: actions/checkout@v2.4.0
       with:
         path: rbe-erlang-platform
-        ref: ${{ matrix.branch }}
+        ref: ${{ env.BRANCH }}
     - name: EXTRACT ARCHIVE
       working-directory: rbe-erlang-platform
       run: |
@@ -56,8 +69,8 @@ jobs:
         path: rbe-erlang-platform
         committer: GitHub <noreply@github.com>
         author: GitHub <noreply@github.com>
-        title: Use latest ${{ matrix.image }}
-        branch: create-pull-request/${{ matrix.branch }}
+        title: Use latest ${{ steps.select-image.outputs.IMAGE }}
+        branch: create-pull-request/${{ env.BRANCH }}
         commit-message: |
-          Use latest ${{ matrix.image }}
+          Use latest ${{ steps.select-image.outputs.IMAGE }}
         delete-branch: true

--- a/.github/workflows/rbe_configs_gen.yaml
+++ b/.github/workflows/rbe_configs_gen.yaml
@@ -53,7 +53,11 @@ jobs:
           --toolchain_container=${{ steps.select-image.outputs.IMAGE }} \
           --output_tarball=rbe_default.tar \
           --exec_os=linux \
-          --target_os=linux
+          --target_os=linux \
+          --cleanup=false
+    - name: Setup tmate session
+      if: always()
+      uses: mxschmitt/action-tmate@v3
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.4.0
       with:

--- a/.github/workflows/rbe_configs_gen.yaml
+++ b/.github/workflows/rbe_configs_gen.yaml
@@ -74,7 +74,10 @@ jobs:
     - name: MAYBE PATCH
       if: ${{ env.BRANCH }} == "buildfarm-shard-worker-rabbitmq-server-buildenv"
       run: |
-        echo TODO
+        sudo npm install --global --silent @bazel/buildozer
+
+        cd rbe-erlang-platform
+        buildozer 'remove exec_properties' //config:platform
     - name: CREATE PULL REQUEST
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
also fixes `buildfarm-shard-worker-rabbitmq-server-buildenv` branch